### PR TITLE
Set CLOUD_PLATFORM to OpenStack Nova in environment of containers.

### DIFF
--- a/nova/virt/lxd/driver.py
+++ b/nova/virt/lxd/driver.py
@@ -1124,6 +1124,7 @@ class LXDDriver(driver.ComputeDriver):
 
         config = {
             'boot.autostart': 'True',  # Start when host reboots
+            'environment.CLOUD_PLATFORM': 'OpenStack Nova',
         }
         if instance.flavor.extra_specs.get('lxd:nested_allowed', False):
             config['security.nesting'] = 'True'


### PR DESCRIPTION
This identifies the host platform as OpenStack Nova to a container.
It allows cloud-init or any other software running inside to know
positively identify the platform.

From inside, the container will see:

 $ tr '\0' '\n' </proc/1/environ
 CLOUD_PLATFORM=OpenStack Nova
 container=lxc

LP: #1661797