### PR TITLE
Lxd images with metadata

### DIFF
--- a/nova/virt/lxd/driver.py
+++ b/nova/virt/lxd/driver.py
@@ -24,10 +24,13 @@ import shutil
 import socket
 import tarfile
 import tempfile
+import hashlib
 
 import eventlet
 import nova.conf
 import nova.context
+from contextlib import closing
+
 from nova import exception
 from nova import i18n
 from nova import image
@@ -236,26 +239,91 @@ def _sync_glance_image_to_lxd(client, context, image_ref):
                     image_id=image_ref, reason=_('Bad image format'))
             IMAGE_API.download(context, image_ref, dest_path=image_file)
 
-            metadata = {
-                'architecture': image.get(
-                    'hw_architecture', obj_fields.Architecture.from_host()),
-                'creation_date': int(os.stat(image_file).st_ctime)}
-            metadata_yaml = json.dumps(
-                metadata, sort_keys=True, indent=4,
-                separators=(',', ': '),
-                ensure_ascii=False).encode('utf-8') + b"\n"
+            # It is possible that LXD already have the same image
+            # but NOT aliased as result of previous publish/export operation
+            # (snapshot from openstack).
+            # In that case attempt to add it again
+            # (implicitly via instance launch from affected image) will produce
+            # LXD error - "Image with same fingerprint already exists".
+            # Error does not unique identifier so # to handle it we calculate
+            # fingerprint of image as LXD do and check if LXD already have image
+            # with such fingerprint.
+            # If any we will add alias to this image and will not re-import it
+            def add_alias():
 
-            tarball = tarfile.open(manifest_file, "w:gz")
-            tarinfo = tarfile.TarInfo(name='metadata.yaml')
-            tarinfo.size = len(metadata_yaml)
-            tarball.addfile(tarinfo, io.BytesIO(metadata_yaml))
-            tarball.close()
+                def lxdimage_fingerprint():
+                    def sha256_file():
+                        sha256 = hashlib.sha256()
+                        with closing(open(image_file, 'rb')) as f:
+                            for block in iter(lambda: f.read(65536), b''):
+                                sha256.update(block)
+                        return sha256.hexdigest()
 
-            with open(manifest_file, 'rb') as manifest:
+                    return sha256_file()
+
+                fingerprint = lxdimage_fingerprint()
+                if client.images.exists(fingerprint):
+                    LOG.info(
+                        'Image already exists {fingerprint} but not accessible '
+                        'by alias ({alias}), updating...'.format(
+                            fingerprint=fingerprint, alias=image_ref))
+                    lxdimage = client.images.get(fingerprint)
+                    lxdimage.add_alias(image_ref, '')
+                    return True
+
+                return False
+
+            if add_alias():
+                return
+
+            # up2date LXD publish/export operations produce images which already
+            # containt /rootfs and metdata.yaml in exported file.
+            # We should not pass metdata explicitly in that case as imported
+            # image will be unusable bacause LXD will think that it containts
+            # rootfs and will not extract embedded /rootfs properly.
+            # Try to detect if image content already has metadata and not pass
+            # explicit metadata in that case
+            def imagefile_has_metadata(image_file):
+                try:
+                    with closing(tarfile.TarFile.open(
+                        name=image_file, mode='r:*')) as tf:
+                        try:
+                            tf.getmember('metadata.yaml')
+                            return True
+                        except KeyError:
+                            pass
+                except tarfile.ReadError:
+                    pass
+                return False
+
+            if imagefile_has_metadata(image_file):
+                LOG.info('Image already {alias} has metadata, '
+                         'skipping metadata injection...'.format(
+                             alias=image_ref))
                 with open(image_file, 'rb') as image:
-                    image = client.images.create(
-                        image.read(), metadata=manifest.read(),
-                        wait=True)
+                    image = client.images.create(image.read(), wait=True)
+            else:
+                metadata = {
+                    'architecture': image.get(
+                        'hw_architecture', obj_fields.Architecture.from_host()),
+                    'creation_date': int(os.stat(image_file).st_ctime)}
+                metadata_yaml = json.dumps(
+                    metadata, sort_keys=True, indent=4,
+                    separators=(',', ': '),
+                    ensure_ascii=False).encode('utf-8') + b"\n"
+
+                tarball = tarfile.open(manifest_file, "w:gz")
+                tarinfo = tarfile.TarInfo(name='metadata.yaml')
+                tarinfo.size = len(metadata_yaml)
+                tarball.addfile(tarinfo, io.BytesIO(metadata_yaml))
+                tarball.close()
+
+                with open(manifest_file, 'rb') as manifest:
+                    with open(image_file, 'rb') as image:
+                        image = client.images.create(
+                            image.read(), metadata=manifest.read(),
+                            wait=True)
+
             image.add_alias(image_ref, '')
 
         finally:

--- a/nova/virt/lxd/driver.py
+++ b/nova/virt/lxd/driver.py
@@ -245,7 +245,7 @@ def _sync_glance_image_to_lxd(client, context, image_ref):
             # In that case attempt to add it again
             # (implicitly via instance launch from affected image) will produce
             # LXD error - "Image with same fingerprint already exists".
-            # Error does not unique identifier so # to handle it we calculate
+            # Error does not have unique identifier so to handle it we calculate
             # fingerprint of image as LXD do and check if LXD already have image
             # with such fingerprint.
             # If any we will add alias to this image and will not re-import it
@@ -297,7 +297,7 @@ def _sync_glance_image_to_lxd(client, context, image_ref):
                 return False
 
             if imagefile_has_metadata(image_file):
-                LOG.info('Image already {alias} has metadata, '
+                LOG.info('Image {alias} already has metadata, '
                          'skipping metadata injection...'.format(
                              alias=image_ref))
                 with open(image_file, 'rb') as image:


### PR DESCRIPTION
First issue - LXD currently export images with embedded metadata and rootfs.
As result following flow does not work:
1. snapshot 
2. launch from snapshot image
The reason:
exported image already has metadata and rootfs inside tarball this image imported to glance.
When instance created from this image driver explicitly generate metadata and pass it to LXD.
LXD does not check image content in that case and assume it contains plain rootfs.
As result when instance launched it's rootfs create in wrong way and has following structure
.../rootfs/rootfs/ instead of normal .../rootfs

Second issue - snapshot creation use LXD publish/export to generate image content to import to glance.
As result LXD already has image on the host but not aliased as expected by Nova.
Attempt to launch instance on the node where snapshot was created will fail as nova will try to import image from glance as it will not find it by internal alias on the node. And LXD will complain that image with the same fingerprint already exists. Proposed fix also lookup image on host by content fingerprint and if it is found just add glance alias to this image so it became usable by nova.